### PR TITLE
refactor(BedwarsUtil): Use proper getX names

### DIFF
--- a/src/main/java/club/maxstats/tabstats/playerapi/api/games/bedwars/Bedwars.java
+++ b/src/main/java/club/maxstats/tabstats/playerapi/api/games/bedwars/Bedwars.java
@@ -73,7 +73,7 @@ public class Bedwars extends BedwarsUtil {
 
     @Override
     public String getFormattedStats() {
-        return String.format("%s%s", getFkdrColor(getFkdr(this)), getFkdr(this));
+        return String.format("%s%s", getFKDRColor(getFKDR(this)), getFKDR(this));
     }
 
     @Override
@@ -112,7 +112,7 @@ public class Bedwars extends BedwarsUtil {
         this.formattedStatList.add(ws);
 
         StatString fkdr = new StatString("FKDR");
-        fkdr.setValue(this.getFkdrColor(this.getFkdr(this)).toString() + this.getFkdr(this));
+        fkdr.setValue(this.getFKDRColor(this.getFKDR(this)).toString() + this.getFKDR(this));
         this.formattedStatList.add(fkdr);
 
         StatString finals = new StatString("FINALS");
@@ -120,7 +120,7 @@ public class Bedwars extends BedwarsUtil {
         this.formattedStatList.add(finals);
 
         StatString wlr = new StatString("WLR");
-        wlr.setValue(this.getWlrColor(this.getWlr(this)).toString() + this.getWlr(this));
+        wlr.setValue(this.getWLRColor(this.getWLR(this)).toString() + this.getWLR(this));
         this.formattedStatList.add(wlr);
 
         StatString wins = new StatString("WINS");
@@ -128,7 +128,7 @@ public class Bedwars extends BedwarsUtil {
         this.formattedStatList.add(wins);
 
         StatString bblr = new StatString("BBLR");
-        bblr.setValue(this.getBblrColor(this.getBblr(this)).toString() + this.getBblr(this));
+        bblr.setValue(this.getBBLRColor(this.getBBLR(this)).toString() + this.getBBLR(this));
         this.formattedStatList.add(bblr);
     }
 }

--- a/src/main/java/club/maxstats/tabstats/playerapi/api/games/bedwars/BedwarsUtil.java
+++ b/src/main/java/club/maxstats/tabstats/playerapi/api/games/bedwars/BedwarsUtil.java
@@ -11,14 +11,14 @@ public abstract class BedwarsUtil extends HGameBase {
         super(playerName, playerUUID);
     }
 
-    public double getFkdr(Bedwars bw) {
+    public double getFKDR(Bedwars bw) {
         return this.formatDouble(((StatInt)bw.finalKills).getValue(), ((StatInt)bw.finalDeaths).getValue());
     }
 
     //this is where I format all the stats and stat colors. You can modify this to your liking
     // Bedwars class is how I handle all the stats that are grabbed, you can also modify which stats are grabbed and add them to the stat list
 
-    public ChatColor getFkdrColor(double fkdr) {
+    public ChatColor getFKDRColor(double fkdr) {
         if (fkdr < 1.5) {
             return ChatColor.GRAY;
         } else if (fkdr < 3.5) {
@@ -38,11 +38,11 @@ public abstract class BedwarsUtil extends HGameBase {
         }
     }
 
-    public double getWlr(Bedwars bw) {
+    public double getWLR(Bedwars bw) {
         return this.formatDouble(((StatInt)bw.wins).getValue(), ((StatInt)bw.losses).getValue());
     }
 
-    public ChatColor getWlrColor(double wlr) {
+    public ChatColor getWLRColor(double wlr) {
         if (wlr < 1) {
             return ChatColor.GRAY;
         } else if (wlr < 2) {
@@ -62,11 +62,11 @@ public abstract class BedwarsUtil extends HGameBase {
         }
     }
 
-    public double getBblr(Bedwars bw) {
+    public double getBBLR(Bedwars bw) {
         return this.formatDouble(((StatInt)bw.bedsBroken).getValue(), ((StatInt)bw.bedsLost).getValue());
     }
 
-    public ChatColor getBblrColor(double bblr) {
+    public ChatColor getBBLRColor(double bblr) {
         if (bblr < 1.5) {
             return ChatColor.GRAY;
         } else if (bblr < 2.5) {


### PR DESCRIPTION
This PR renames some of the getters in `BedwarsUtil`, namely
- `getFkdr` → `getFKDR`
- `getFkdrColor` -> `getFKDRColor`
- `getWlr` → `getWLR`
- `getWlrColor` → `getWLRColor`
- `getBblr` → `getBBLR`
- `getBblrColor` → `getBBLRColor`

The reason for these changes is to use proper acronyms when naming the getters.
**F**inal **K**ill **D**eath **R**atio
**W**in **L**oss **R**atio
**B**ed **B**reak **L**oss **R**atio

Winstreak should stay `getWS` as "winstreak" is a shortened form of Winning Streak